### PR TITLE
Update maven-assembly-plugin to 3.7.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
         retention-days: 5
     - id: linkchecker
       name: Link Checker
-      uses: lycheeverse/lychee-action@f81112d0d2814ded911bd23e3beaa9dda9093915
+      uses: lycheeverse/lychee-action@f613c4a64e50d792e0b31ec34bbcbba12263c6a6
       with:
         args: --verbose --no-progress --accept 200,206,429 './target/staging/**/*.html'  --remap "https://github.com/metaschema-framework/oss-maven/tree/main/ file://${GITHUB_WORKSPACE}/" --remap "https://oss-maven.metaschema.dev/ file://${GITHUB_WORKSPACE}/target/staging/" --exclude-mail
         format: markdown

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         maven-version: ${{ env.MAVEN_VERSION }}
     - name: Set up JDK 11
-      uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
+      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12
       with:
         java-version-file: ${{ env.JAVA_VERSION_FILE }}
         distribution: ${{ env.JAVA_DISTRO }}
@@ -112,7 +112,7 @@ jobs:
       with:
         maven-version: ${{ env.MAVEN_VERSION }}
     - name: Set up JDK 11
-      uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
+      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12
       with:
         java-version-file: ${{ env.JAVA_VERSION_FILE }}
         distribution:  ${{ env.JAVA_DISTRO }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
       run: |
         zip ${{ runner.temp }}/website.zip -r target/staging
     - name: Upload generated site
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
       with:
         name: website
         path: |
@@ -146,7 +146,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       continue-on-error: true
     - name: Upload link check report
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
       with:
         name: html-link-report
         path: html-link-report.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         maven-version: ${{ env.MAVEN_VERSION }}
     - name: Set up JDK 11
-      uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
+      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12
       with:
         java-version-file: ${{ env.JAVA_VERSION_FILE }}
         distribution: ${{ env.JAVA_DISTRO }}
@@ -72,7 +72,7 @@ jobs:
       with:
         maven-version: ${{ env.MAVEN_VERSION }}
     - name: Set up JDK 11
-      uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
+      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12
       with:
         java-version-file: ${{ env.JAVA_VERSION_FILE }}
         distribution: ${{ env.JAVA_DISTRO }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ release.properties
 .pmd
 .factorypath
 /maven2
+
+# Claude
+CLAUDE.local.md

--- a/oss-build-support/pom.xml
+++ b/oss-build-support/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>dev.metaschema</groupId>
 		<artifactId>oss-maven</artifactId>
-		<version>6</version>
+		<version>7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>oss-build-support</artifactId>
@@ -25,7 +25,7 @@
 
 	<scm>
 		<url>${scm.url}/tree/develop/oss-build-support</url>
-	  <tag>v6</tag>
+	  <tag>v4</tag>
   </scm>
 
 	<dependencies>

--- a/oss-build-support/pom.xml
+++ b/oss-build-support/pom.xml
@@ -44,13 +44,13 @@
 			<!-- fix for missing runtime dependency -->
 			<groupId>com.github.javaparser</groupId>
 		    <artifactId>javaparser-symbol-solver-core</artifactId>
-			<version>3.26.1</version>
+			<version>${dependency.javaparser-symbol-solver-core.version}</version>
 		</dependency>
 		<dependency>
 			<!-- fix for missing runtime dependency -->
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.23.1</version>
+			<version>${dependency.log4j.version}</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/oss-build-support/pom.xml
+++ b/oss-build-support/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>dev.metaschema</groupId>
 		<artifactId>oss-maven</artifactId>
-		<version>8</version>
+		<version>9-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>oss-build-support</artifactId>
@@ -25,7 +25,7 @@
 
 	<scm>
 		<url>${scm.url}/tree/develop/oss-build-support</url>
-	  <tag>v8</tag>
+	  <tag>v4</tag>
   </scm>
 
 	<dependencies>

--- a/oss-build-support/pom.xml
+++ b/oss-build-support/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>dev.metaschema</groupId>
 		<artifactId>oss-maven</artifactId>
-		<version>7</version>
+		<version>8-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>oss-build-support</artifactId>
@@ -25,7 +25,7 @@
 
 	<scm>
 		<url>${scm.url}/tree/develop/oss-build-support</url>
-	  <tag>v7</tag>
+	  <tag>v4</tag>
   </scm>
 
 	<dependencies>

--- a/oss-build-support/pom.xml
+++ b/oss-build-support/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>dev.metaschema</groupId>
 		<artifactId>oss-maven</artifactId>
-		<version>7-SNAPSHOT</version>
+		<version>7</version>
 	</parent>
 
 	<artifactId>oss-build-support</artifactId>
@@ -25,7 +25,7 @@
 
 	<scm>
 		<url>${scm.url}/tree/develop/oss-build-support</url>
-	  <tag>v4</tag>
+	  <tag>v7</tag>
   </scm>
 
 	<dependencies>

--- a/oss-build-support/pom.xml
+++ b/oss-build-support/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>dev.metaschema</groupId>
 		<artifactId>oss-maven</artifactId>
-		<version>8-SNAPSHOT</version>
+		<version>8</version>
 	</parent>
 
 	<artifactId>oss-build-support</artifactId>
@@ -25,7 +25,7 @@
 
 	<scm>
 		<url>${scm.url}/tree/develop/oss-build-support</url>
-	  <tag>v4</tag>
+	  <tag>v8</tag>
   </scm>
 
 	<dependencies>

--- a/oss-build-support/src/main/resources/checkstyle/checkstyle.xml
+++ b/oss-build-support/src/main/resources/checkstyle/checkstyle.xml
@@ -80,7 +80,10 @@
 		<module name="OneStatementPerLine" />
 		<module name="MultipleVariableDeclarations" />
 		<module name="ArrayTypeStyle" />
-		<module name="MissingSwitchDefault" />
+		<module name="MissingSwitchDefault">
+			<!-- enforcing this prevents these issues from being found at compile time-->
+			<property name="severity" value="ignore" />
+		</module>
 		<module name="FallThrough" />
 		<module name="UpperEll" />
 		<module name="ModifierOrder" />

--- a/oss-parent/pom.xml
+++ b/oss-parent/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>dev.metaschema</groupId>
 		<artifactId>oss-maven</artifactId>
-		<version>6</version>
+		<version>7-SNAPSHOT</version>
 	</parent>
 	<artifactId>oss-parent</artifactId>
 	<packaging>pom</packaging>
@@ -21,7 +21,7 @@
 
 	<scm>
 		<url>${scm.url}/tree/develop/oss-parent</url>
-	  <tag>v6</tag>
+	  <tag>v4</tag>
   </scm>
 
 	<build>
@@ -53,7 +53,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>6</version>
+							<version>7-SNAPSHOT</version>
 						</dependency>
 					</dependencies>
 				</plugin>
@@ -102,7 +102,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>6</version>
+							<version>7-SNAPSHOT</version>
 						</dependency>
 					</dependencies>
 				</plugin>
@@ -140,7 +140,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>6</version>
+							<version>7-SNAPSHOT</version>
 						</dependency>
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>
@@ -214,7 +214,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>6</version>
+							<version>7-SNAPSHOT</version>
 						</dependency>
 					</dependencies>
 				</plugin>

--- a/oss-parent/pom.xml
+++ b/oss-parent/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>dev.metaschema</groupId>
 		<artifactId>oss-maven</artifactId>
-		<version>8-SNAPSHOT</version>
+		<version>8</version>
 	</parent>
 	<artifactId>oss-parent</artifactId>
 	<packaging>pom</packaging>
@@ -21,7 +21,7 @@
 
 	<scm>
 		<url>${scm.url}/tree/develop/oss-parent</url>
-	  <tag>v4</tag>
+	  <tag>v8</tag>
   </scm>
 
 	<build>
@@ -53,7 +53,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>8-SNAPSHOT</version>
+							<version>8</version>
 						</dependency>
 					</dependencies>
 				</plugin>
@@ -102,7 +102,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>8-SNAPSHOT</version>
+							<version>8</version>
 						</dependency>
 					</dependencies>
 				</plugin>
@@ -140,7 +140,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>8-SNAPSHOT</version>
+							<version>8</version>
 						</dependency>
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>
@@ -214,7 +214,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>8-SNAPSHOT</version>
+							<version>8</version>
 						</dependency>
 					</dependencies>
 				</plugin>

--- a/oss-parent/pom.xml
+++ b/oss-parent/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>dev.metaschema</groupId>
 		<artifactId>oss-maven</artifactId>
-		<version>8</version>
+		<version>9-SNAPSHOT</version>
 	</parent>
 	<artifactId>oss-parent</artifactId>
 	<packaging>pom</packaging>
@@ -21,7 +21,7 @@
 
 	<scm>
 		<url>${scm.url}/tree/develop/oss-parent</url>
-	  <tag>v8</tag>
+	  <tag>v4</tag>
   </scm>
 
 	<build>
@@ -53,7 +53,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>8</version>
+							<version>9-SNAPSHOT</version>
 						</dependency>
 					</dependencies>
 				</plugin>
@@ -102,7 +102,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>8</version>
+							<version>9-SNAPSHOT</version>
 						</dependency>
 					</dependencies>
 				</plugin>
@@ -140,7 +140,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>8</version>
+							<version>9-SNAPSHOT</version>
 						</dependency>
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>
@@ -214,7 +214,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>8</version>
+							<version>9-SNAPSHOT</version>
 						</dependency>
 					</dependencies>
 				</plugin>

--- a/oss-parent/pom.xml
+++ b/oss-parent/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>dev.metaschema</groupId>
 		<artifactId>oss-maven</artifactId>
-		<version>7</version>
+		<version>8-SNAPSHOT</version>
 	</parent>
 	<artifactId>oss-parent</artifactId>
 	<packaging>pom</packaging>
@@ -21,7 +21,7 @@
 
 	<scm>
 		<url>${scm.url}/tree/develop/oss-parent</url>
-	  <tag>v7</tag>
+	  <tag>v4</tag>
   </scm>
 
 	<build>
@@ -53,7 +53,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>7</version>
+							<version>8-SNAPSHOT</version>
 						</dependency>
 					</dependencies>
 				</plugin>
@@ -102,7 +102,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>7</version>
+							<version>8-SNAPSHOT</version>
 						</dependency>
 					</dependencies>
 				</plugin>
@@ -140,7 +140,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>7</version>
+							<version>8-SNAPSHOT</version>
 						</dependency>
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>
@@ -214,7 +214,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>7</version>
+							<version>8-SNAPSHOT</version>
 						</dependency>
 					</dependencies>
 				</plugin>

--- a/oss-parent/pom.xml
+++ b/oss-parent/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>dev.metaschema</groupId>
 		<artifactId>oss-maven</artifactId>
-		<version>7-SNAPSHOT</version>
+		<version>7</version>
 	</parent>
 	<artifactId>oss-parent</artifactId>
 	<packaging>pom</packaging>
@@ -21,7 +21,7 @@
 
 	<scm>
 		<url>${scm.url}/tree/develop/oss-parent</url>
-	  <tag>v4</tag>
+	  <tag>v7</tag>
   </scm>
 
 	<build>
@@ -53,7 +53,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>7-SNAPSHOT</version>
+							<version>7</version>
 						</dependency>
 					</dependencies>
 				</plugin>
@@ -102,7 +102,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>7-SNAPSHOT</version>
+							<version>7</version>
 						</dependency>
 					</dependencies>
 				</plugin>
@@ -140,7 +140,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>7-SNAPSHOT</version>
+							<version>7</version>
 						</dependency>
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>
@@ -214,7 +214,7 @@
 						<dependency>
 							<groupId>dev.metaschema</groupId>
 							<artifactId>oss-build-support</artifactId>
-							<version>7-SNAPSHOT</version>
+							<version>7</version>
 						</dependency>
 					</dependencies>
 				</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dev.metaschema</groupId>
 	<artifactId>oss-maven</artifactId>
-	<version>6</version>
+	<version>7-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Build Root</name>
 	<description>A common build root for all Metaschema projects.</description>
@@ -87,7 +87,7 @@
 		<connection>scm:git:ssh://git@github.com/metaschema-framework/oss-maven.git</connection>
 		<developerConnection>
 			scm:git:ssh://git@github.com/metaschema-framework/oss-maven.git</developerConnection>
-		<tag>v6</tag>
+		<tag>v4</tag>
 	</scm>
 	<distributionManagement>
 		<repository>
@@ -135,7 +135,7 @@
 			<dependency>
 				<groupId>dev.metaschema</groupId>
 				<artifactId>oss-build-support</artifactId>
-				<version>6</version>
+				<version>7-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<dependency.javaparser-symbol-solver-core.version>3.26.3</dependency.javaparser-symbol-solver-core.version>
 
 		<plugin.maven-antrun.version>3.1.0</plugin.maven-antrun.version>
-		<plugin.maven-assembly.version>3.7.1</plugin.maven-assembly.version>
+		<plugin.maven-assembly.version>3.8.0</plugin.maven-assembly.version>
 		<plugin.maven-checkstyle.version>3.6.0</plugin.maven-checkstyle.version>
 		<plugin.maven-clean.version>3.4.0</plugin.maven-clean.version>
 		<plugin.maven-compile.version>3.13.0</plugin.maven-compile.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		
 		<mojo.maven.version>3.8.1</mojo.maven.version>
 
-		<dependency.asm.version>9.7.1</dependency.asm.version>
+		<dependency.asm.version>9.9</dependency.asm.version>
 		<dependency.checkstyle.version>10.21.3</dependency.checkstyle.version>
 		<dependency.doxia-site-tools.version>2.0.0-M18</dependency.doxia-site-tools.version>
 		<dependency.extra-enforcer-rules.version>1.9.0</dependency.extra-enforcer-rules.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dev.metaschema</groupId>
 	<artifactId>oss-maven</artifactId>
-	<version>7</version>
+	<version>8-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Build Root</name>
 	<description>A common build root for all Metaschema projects.</description>
@@ -91,7 +91,7 @@
 		<connection>scm:git:ssh://git@github.com/metaschema-framework/oss-maven.git</connection>
 		<developerConnection>
 			scm:git:ssh://git@github.com/metaschema-framework/oss-maven.git</developerConnection>
-		<tag>v7</tag>
+		<tag>v4</tag>
 	</scm>
 	<distributionManagement>
 		<repository>
@@ -139,7 +139,7 @@
 			<dependency>
 				<groupId>dev.metaschema</groupId>
 				<artifactId>oss-build-support</artifactId>
-				<version>7</version>
+				<version>8-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 		<plugin.spotbugs.version>4.8.6.6</plugin.spotbugs.version>
 		<plugin.taglist.version>3.2.1</plugin.taglist.version>
 		<plugin.versions.version>2.18.0</plugin.versions.version>
-		<plugin.central-plublishing.version>0.6.0</plugin.central-plublishing.version>
+		<plugin.central-plublishing.version>0.7.0</plugin.central-plublishing.version>
 	</properties>
 	<issueManagement>
 		<url>${issueManagement.url}</url>
@@ -777,7 +777,7 @@
 					<plugin>
 			          <groupId>org.sonatype.central</groupId>
 			          <artifactId>central-publishing-maven-plugin</artifactId>
-			          <version>0.5.0</version>
+			          <version>0.7.0</version>
 			          <extensions>true</extensions>
 			          <configuration>
 			             <publishingServerId>central</publishingServerId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,16 +26,19 @@
 		
 		<mojo.maven.version>3.8.1</mojo.maven.version>
 
-		<dependency.asm.version>9.7</dependency.asm.version>
-		<dependency.checkstyle.version>10.17.0</dependency.checkstyle.version>
+		<dependency.asm.version>9.7.1</dependency.asm.version>
+		<dependency.checkstyle.version>10.21.3</dependency.checkstyle.version>
 		<dependency.doxia-site-tools.version>2.0.0-M18</dependency.doxia-site-tools.version>
-		<dependency.extra-enforcer-rules.version>1.8.0</dependency.extra-enforcer-rules.version>
-		<dependency.junit5.version>5.11.3</dependency.junit5.version>
-		<dependency.junit5.version>5.11.0</dependency.junit5.version>
+		<dependency.extra-enforcer-rules.version>1.9.0</dependency.extra-enforcer-rules.version>
+		<dependency.junit.version>4.13.2</dependency.junit.version>
+		<dependency.junit5.version>5.12.0</dependency.junit5.version>
+		<dependency.log4j.version>2.24.3</dependency.log4j.version>
 		<dependency.maven-plugin-tools.version>3.15.1</dependency.maven-plugin-tools.version>
-		<dependency.pmd.version>7.7.0</dependency.pmd.version>
-		<dependency.spotbugs-annotations.version>4.8.6</dependency.spotbugs-annotations.version>
-		<dependency.xmlbeans.version>5.2.2</dependency.xmlbeans.version>
+		<dependency.pmd.version>7.10.0</dependency.pmd.version>
+		<dependency.spotbugs-annotations.version>4.9.1</dependency.spotbugs-annotations.version>
+		<dependency.xmlbeans.version>5.3.0</dependency.xmlbeans.version>
+		<!-- fix for missing runtime dependency for xmlbeans -->
+		<dependency.javaparser-symbol-solver-core.version>3.26.3</dependency.javaparser-symbol-solver-core.version>
 
 		<plugin.maven-antrun.version>3.1.0</plugin.maven-antrun.version>
 		<plugin.maven-assembly.version>3.7.1</plugin.maven-assembly.version>
@@ -57,6 +60,7 @@
 		<plugin.maven-pmd.version>3.26.0</plugin.maven-pmd.version>
 		<plugin.maven-project-info-reports.version>3.8.0</plugin.maven-project-info-reports.version>
 		<plugin.maven-release.version>3.1.1</plugin.maven-release.version>
+		<plugin.maven-reporting-api.version>4.0.0</plugin.maven-reporting-api.version>
 		<plugin.maven-resources.version>3.3.1</plugin.maven-resources.version>
 		<plugin.maven-scm.version>2.1.0</plugin.maven-scm.version>
 		<plugin.maven-scm-publish.version>3.3.0</plugin.maven-scm-publish.version>
@@ -579,7 +583,7 @@
 						<dependency>
 							<groupId>org.apache.maven.reporting</groupId>
 							<artifactId>maven-reporting-api</artifactId>
-							<version>4.0.0-M12</version>
+							<version>${plugin.maven-reporting-api.version}</version>
 						</dependency>
 					</dependencies>
 				</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dev.metaschema</groupId>
 	<artifactId>oss-maven</artifactId>
-	<version>8</version>
+	<version>9-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Build Root</name>
 	<description>A common build root for all Metaschema projects.</description>
@@ -91,7 +91,7 @@
 		<connection>scm:git:ssh://git@github.com/metaschema-framework/oss-maven.git</connection>
 		<developerConnection>
 			scm:git:ssh://git@github.com/metaschema-framework/oss-maven.git</developerConnection>
-		<tag>v8</tag>
+		<tag>v4</tag>
 	</scm>
 	<distributionManagement>
 		<repository>
@@ -139,7 +139,7 @@
 			<dependency>
 				<groupId>dev.metaschema</groupId>
 				<artifactId>oss-build-support</artifactId>
-				<version>8</version>
+				<version>9-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dev.metaschema</groupId>
 	<artifactId>oss-maven</artifactId>
-	<version>7-SNAPSHOT</version>
+	<version>7</version>
 	<packaging>pom</packaging>
 	<name>Build Root</name>
 	<description>A common build root for all Metaschema projects.</description>
@@ -91,7 +91,7 @@
 		<connection>scm:git:ssh://git@github.com/metaschema-framework/oss-maven.git</connection>
 		<developerConnection>
 			scm:git:ssh://git@github.com/metaschema-framework/oss-maven.git</developerConnection>
-		<tag>v4</tag>
+		<tag>v7</tag>
 	</scm>
 	<distributionManagement>
 		<repository>
@@ -139,7 +139,7 @@
 			<dependency>
 				<groupId>dev.metaschema</groupId>
 				<artifactId>oss-build-support</artifactId>
-				<version>7-SNAPSHOT</version>
+				<version>7</version>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dev.metaschema</groupId>
 	<artifactId>oss-maven</artifactId>
-	<version>8-SNAPSHOT</version>
+	<version>8</version>
 	<packaging>pom</packaging>
 	<name>Build Root</name>
 	<description>A common build root for all Metaschema projects.</description>
@@ -91,7 +91,7 @@
 		<connection>scm:git:ssh://git@github.com/metaschema-framework/oss-maven.git</connection>
 		<developerConnection>
 			scm:git:ssh://git@github.com/metaschema-framework/oss-maven.git</developerConnection>
-		<tag>v4</tag>
+		<tag>v8</tag>
 	</scm>
 	<distributionManagement>
 		<repository>
@@ -139,7 +139,7 @@
 			<dependency>
 				<groupId>dev.metaschema</groupId>
 				<artifactId>oss-build-support</artifactId>
-				<version>8-SNAPSHOT</version>
+				<version>8</version>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>


### PR DESCRIPTION
## Summary
- Updates maven-assembly-plugin from 3.7.1 to 3.7.2
- Fixes "Failed to build parent project" warnings (MASSEMBLY-1029)

## Test plan
- Build a downstream project that uses the assembly plugin and verify no warnings appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/build workflows to use newer action/tool versions.
  * Bumped project and parent build-tool/plugin/dependency versions for modernized builds.
  * Added a local development file to .gitignore.
* **Style**
  * Tuned static-analysis configuration to suppress noise from missing-switch-default checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->