### PR TITLE
Update GitHub Actions runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ env:
 jobs:
   build-code:
     name: Code
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read
@@ -95,7 +95,7 @@ jobs:
 #        upload: ${{ github.ref_name == 'develop' && 'always' || 'never' }}
   build-website:
     name: Website
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   add-to-project:
     name: Add issue to project
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   deploy-to-nexus:
     name: Maven Central Deployment
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read
@@ -50,7 +50,7 @@ jobs:
         MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   deploy-website:
     name: Website Deployment
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: write


### PR DESCRIPTION
## Summary
- Update GitHub Actions runners from ubuntu-20.04 to ubuntu-24.04
- Ubuntu 20.04 reaches end of life in April 2025

## Files changed
- `.github/workflows/build.yml` - Code and Website jobs
- `.github/workflows/issue-triage.yml` - Add issue to project job
- `.github/workflows/release.yml` - Maven Central and Website deployment jobs

## Test plan
- [ ] Verify CI builds pass on the new runner
- [ ] Verify website deployment works correctly