### PR TITLE
Fix git config order in Deploy Artifacts workflow step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,10 +82,12 @@ jobs:
       run: |
         MVN_COORDS=$(echo '${project.groupId}:${project.artifactId}:${project.version}' | mvn -N -q -DforceStdout help:evaluate)
         cd maven2
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
         git pull -r -s ours --autostash
-        git add -A
         git config user.name "$(git log -n 1 --pretty=format:%an)"
         git config user.email "$(git log -n 1 --pretty=format:%ae)"
+        git add -A
         git commit -m "[CI SKIP] Deploying artifacts for $MVN_COORDS."
         git push
 #    - name: Perform CodeQL Analysis


### PR DESCRIPTION
## Summary
- Move `git config user.name` and `git config user.email` before `git pull -r -s ours --autostash`
- The rebase operation during `git pull -r` requires git identity to be configured first

## Problem
The workflow was failing with:
```
fatal: empty ident name (for <runner@...>) not allowed
```

This occurred because `git pull -r -s ours --autostash` runs a rebase which needs committer identity, but the git config commands were placed after the pull.

## Test plan
- [ ] Verify the Deploy Artifacts step completes successfully on develop branch