### PR TITLE
Remove deprecated --exclude-mail flag from lychee-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
       name: Link Checker
       uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0
       with:
-        args: --verbose --no-progress --accept 200,206,429 './target/staging/**/*.html'  --remap "https://github.com/metaschema-framework/oss-maven/tree/main/ file://${GITHUB_WORKSPACE}/" --remap "https://oss-maven.metaschema.dev/ file://${GITHUB_WORKSPACE}/target/staging/" --exclude-mail
+        args: --verbose --no-progress --accept 200,206,429 './target/staging/**/*.html'  --remap "https://github.com/metaschema-framework/oss-maven/tree/main/ file://${GITHUB_WORKSPACE}/" --remap "https://oss-maven.metaschema.dev/ file://${GITHUB_WORKSPACE}/target/staging/"
         format: markdown
         output: html-link-report.md
         debug: true


### PR DESCRIPTION
## Summary

Remove the deprecated `--exclude-mail` flag from lychee-action configuration.

- The `--exclude-mail` flag was removed in lychee-action v2.5.0
- Email addresses are now excluded from checking by default
- This change is required before upgrading lychee-action to a newer version

## Test plan

- [ ] Verify workflow runs successfully without the flag
- [ ] After merge, upgrade lychee-action to latest version