### PR TITLE
Misc updates: fix typo, bump maven version, update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ release.properties
 
 # Claude
 CLAUDE.local.md
+/.claude/settings.local.json

--- a/oss-build-support/src/main/resources/checkstyle/eclipse/eclipse-cs.xml
+++ b/oss-build-support/src/main/resources/checkstyle/eclipse/eclipse-cs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <profiles version="2">
-    <profile kind="CleanUpProfile" name="SecAuto Checksyle" version="2">
+    <profile kind="CleanUpProfile" name="SecAuto Checkstyle" version="2">
         <setting id="cleanup.array_with_curly" value="true"/>
         <setting id="cleanup.use_autoboxing" value="true"/>
         <setting id="cleanup.overridden_assignment_move_decl" value="true"/>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<maven.compiler.release>11</maven.compiler.release>
 		<javac.debuglevel>lines,source,vars</javac.debuglevel>
 		
-		<mojo.maven.version>3.8.1</mojo.maven.version>
+		<mojo.maven.version>3.9.0</mojo.maven.version>
 
 		<dependency.asm.version>9.9</dependency.asm.version>
 		<dependency.checkstyle.version>10.21.3</dependency.checkstyle.version>


### PR DESCRIPTION
## Summary
- Fix typo in eclipse-cs.xml: "Checksyle" → "Checkstyle"
- Bump mojo.maven.version from 3.8.1 to 3.9.0
- Add .claude/settings.local.json to .gitignore

## Test plan
- [ ] Verify CI passes
- [ ] Confirm changes are minor and non-breaking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration ignore patterns for local settings
  * Corrected a profile name in the build configuration system
  * Updated Maven plugin version for improved stability and compatibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->