### PR TITLE
Add impsort-maven-plugin for automatic import sorting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "extraKnownMarketplaces": {
+    "metaschema-framework": {
+      "source": {
+        "source": "github",
+        "repo": "metaschema-framework/claude-plugins"
+      }
+    },
+    "superpowers-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "obra/superpowers"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "dev-metaschema@metaschema-framework": true,
+    "superpowers@superpowers-marketplace": true
+  }
+}

--- a/oss-parent/pom.xml
+++ b/oss-parent/pom.xml
@@ -58,6 +58,19 @@
 					</dependencies>
 				</plugin>
 				<plugin>
+					<groupId>net.revelc.code</groupId>
+					<artifactId>impsort-maven-plugin</artifactId>
+					<executions>
+						<execution>
+							<id>sort-imports</id>
+							<phase>process-sources</phase>
+							<goals>
+								<goal>sort</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
 					<groupId>com.mycila</groupId>
 					<artifactId>license-maven-plugin</artifactId>
 					<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
 
 		<plugin.build-helper.version>3.6.1</plugin.build-helper.version>
 		<plugin.formatter.version>2.29.0</plugin.formatter.version>
+		<plugin.impsort.version>1.12.0</plugin.impsort.version>
 		<plugin.jacoco.version>0.8.12</plugin.jacoco.version>
 		<plugin.jdepend.version>2.1</plugin.jdepend.version>
 		<plugin.license.version>5.0.0</plugin.license.version>
@@ -348,6 +349,22 @@
 					<groupId>net.revelc.code.formatter</groupId>
 					<artifactId>formatter-maven-plugin</artifactId>
 					<version>${plugin.formatter.version}</version>
+				</plugin>
+				<plugin>
+					<groupId>net.revelc.code</groupId>
+					<artifactId>impsort-maven-plugin</artifactId>
+					<version>${plugin.impsort.version}</version>
+					<configuration>
+						<!-- Match checkstyle.importorder: #,com,gov,net,org,java,javax,* -->
+						<groups>com.,gov.,net.,org.,java.,javax.,*</groups>
+						<staticGroups>*</staticGroups>
+						<staticAfter>false</staticAfter>
+						<removeUnused>true</removeUnused>
+						<!-- Exclude module-info.java - imports are used in provides clauses -->
+						<excludes>
+							<exclude>**/module-info.java</exclude>
+						</excludes>
+					</configuration>
 				</plugin>
 				<!-- ========================= -->
 				<!-- process-resources         -->
@@ -651,6 +668,10 @@
 			<plugin>
 				<groupId>net.revelc.code.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>net.revelc.code</groupId>
+				<artifactId>impsort-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

- Adds the `impsort-maven-plugin` (v1.12.0) to automatically enforce consistent import ordering across the codebase
- Configures import groups to match existing checkstyle configuration: `com`, `gov`, `net`, `org`, `java`, `javax`, then others
- Excludes `module-info.java` files from sorting since imports are used in provides clauses
- Binds the plugin to the `process-sources` phase for automatic execution during builds

## Test plan

- [x] Run `mvn impsort:check` to verify the plugin configuration works correctly
- [x] Run a full build to ensure the plugin integrates properly with the existing build process
- [x] Verify that import sorting matches the checkstyle import order configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped project version to 10-SNAPSHOT
  * Updated build tool and dependency versions
  * Updated GitHub Actions workflow references

* **Refactor**
  * Added automated import sorting tool to build process

* **Bug Fixes**
  * Corrected checkstyle profile configuration name

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->